### PR TITLE
Don't modify headers hash in `open!` method

### DIFF
--- a/lib/rack/stream/handlers.rb
+++ b/lib/rack/stream/handlers.rb
@@ -47,7 +47,7 @@ module Rack
 
         # @private
         def open!
-          @app.headers.delete('Content-Length')
+          @app.headers = @app.headers.select { |key| key != 'Content-Length' }
           open
         end
 


### PR DESCRIPTION
E.g. in case if I have a frozen hash it shows me an error: "can't modify frozen Hash (RuntimeError)"

``` ruby
class EventHandler
  include Rack::Stream::DSL

  STATUS = 200
  HEADERS = {
    'Content-Type'  => 'text/event-stream; charset=UTF-8',
    'Connection'    => 'keepalive',
    'Cache-Control' => 'no-cache, no-store'
  }

  stream do
    ...
    [STATUS, HEADERS, []]
  end
end
```
