### PR TITLE
Rack::Utils.bytesize is no longer available

### DIFF
--- a/lib/rack/stream/handlers/http.rb
+++ b/lib/rack/stream/handlers/http.rb
@@ -31,7 +31,7 @@ module Rack
           # hack to work with Rack::File for now, should not TE chunked
           # things that aren't strings or respond to bytesize
           c = ::File.read(c.path) if c.kind_of?(Rack::File)
-          size = Rack::Utils.bytesize(c)
+          size = c.bytesize
           return nil if size == 0
           c.dup.force_encoding(Encoding::BINARY) if c.respond_to?(:force_encoding)
           [size.to_s(16), TERM, c, TERM].join

--- a/rack-stream.gemspec
+++ b/rack-stream.gemspec
@@ -2,7 +2,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "rack-stream"
-  s.version     = "0.0.5"
+  s.version     = "0.0.6"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Jerry Cheung"]
   s.email       = ["jerry@intridea.com"]
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Rack middleware for building multi-protocol streaming rack endpoints}
   s.description = %q{Rack middleware for building multi-protocol streaming rack endpoints}
   s.license     = "BSD"
+  s.required_ruby_version = '>= 1.9.3'
 
   s.rubyforge_project = "rack-stream"
 


### PR DESCRIPTION
Replace with native String.bytesize since Ruby 1.9.3.
